### PR TITLE
wifi: resurrect mWifiLinkLayerStatsSupported counter

### DIFF
--- a/service/java/com/android/server/wifi/ClientModeImpl.java
+++ b/service/java/com/android/server/wifi/ClientModeImpl.java
@@ -345,6 +345,8 @@ public class ClientModeImpl extends StateMachine implements ClientMode {
     private DetailedState mNetworkAgentState;
     private final SupplicantStateTracker mSupplicantStateTracker;
 
+    private int mWifiLinkLayerStatsSupported = 4; // Temporary disable
+
     // Indicates that framework is attempting to roam, set true on CMD_START_ROAM, set false when
     // wifi connects or fails to connect
     private boolean mIsAutoRoaming = false;
@@ -1409,22 +1411,20 @@ public class ClientModeImpl extends StateMachine implements ClientMode {
             loge("getWifiLinkLayerStats called without an interface");
             return null;
         }
-        mLastLinkLayerStatsUpdate = mClock.getWallClockMillis();
         WifiLinkLayerStats stats = null;
-        if (isPrimary()) {
+        mLastLinkLayerStatsUpdate = mClock.getWallClockMillis();
+        if (mWifiLinkLayerStatsSupported > 0) {
             stats = mWifiNative.getWifiLinkLayerStats(mInterfaceName);
-        } else {
-            if (mVerboseLoggingEnabled) {
-                Log.w(getTag(), "Can't getWifiLinkLayerStats on secondary iface");
+            if (stats == null) {
+                mWifiLinkLayerStatsSupported -= 1;
+            } else {
+                mOnTime = stats.on_time;
+                mTxTime = stats.tx_time;
+                mRxTime = stats.rx_time;
+                mRunningBeaconCount = stats.beacon_rx;
+                mWifiInfo.updatePacketRates(stats, mLastLinkLayerStatsUpdate);
             }
-        }
-        if (stats != null) {
-            mOnTime = stats.on_time;
-            mTxTime = stats.tx_time;
-            mRxTime = stats.rx_time;
-            mRunningBeaconCount = stats.beacon_rx;
-            mWifiInfo.updatePacketRates(stats, mLastLinkLayerStatsUpdate);
-        } else {
+        } else { // LinkLayerStats are broken or unsupported
             long mTxPkts = mFacade.getTxPackets(mInterfaceName);
             long mRxPkts = mFacade.getRxPackets(mInterfaceName);
             mWifiInfo.updatePacketRates(mTxPkts, mRxPkts, mLastLinkLayerStatsUpdate);


### PR DESCRIPTION
On devices with broken/not implemented LinkLayerStats the counter mWifiLinkLayerStatsSupported prevents the following error messages from appearing every 3 seconds.

03-08 10:43:02.616   389   389 E WifiHAL : wifi_get_link_stats: requestResponse Error:-3
03-08 10:43:02.617  2030  2206 E WifiVendorHal: getWifiLinkLayerStats(l.937) failed {.code = ERROR_NOT_SUPPORTED, .description = }

This partially reverts commit 1ba5b5858ffc04acbd317dc1f6789f1777d375e6.

Change-Id: I840f9d1304bf0a31e7a6b65db00a37dc3651e4b8